### PR TITLE
apt install error

### DIFF
--- a/bitcoin-testnet/Dockerfile
+++ b/bitcoin-testnet/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-RUN apt-get update && apt-get install -qy git
+RUN apt-get update && apt-get install -qy git 
 RUN apt-get install -qy build-essential
 RUN apt-get install -qy libboost-all-dev
 RUN apt-get install -qy libssl-dev libdb++-dev libdb-dev libminiupnpc-dev
@@ -14,8 +14,8 @@ RUN ./autogen.sh
 RUN ./configure --with-incompatible-bdb
 RUN make
 
-EXPOSE 8333
+EXPOSE 18333
 VOLUME /root/.bitcoin
 
 ADD bitcoin.conf /root/.bitcoin/bitcoin.conf
-CMD ./src/bitcoind -debug
+CMD ./src/bitcoind -server -debug -testnet

--- a/bitcoin-testnet/README
+++ b/bitcoin-testnet/README
@@ -1,0 +1,14 @@
+useful commands:
+```
+docker build -t allofthecoins:bitcoin ./
+docker run --name bitcoin -itd allofthecoins:bitcoin
+docker exec -it ./src/bitcoin-cli getinfo
+docker exec -it tail -F /root/.bitcoin/debug.log
+```
+
+
+Runs the bitcoin node, listens of port 8333 on the host, listens for local RPC connections on 8332
+
+```
+docker run --name bitcoin -itd -p 8333:8333 -p 127.0.0.1:8332:8332 -v bitcoind-data:/root/.bitcoin allofthecoins:bitcoin
+```

--- a/bitcoin-testnet/bitcoin.conf
+++ b/bitcoin-testnet/bitcoin.conf
@@ -1,0 +1,5 @@
+rpcuser=bitcoinrpc
+rpcpassword=2ESKpSWXtheVSDKf8DHLAaZj6hNbjhxZcGY9niwoqzci
+testnet=1
+server=1
+rpcallowip=172.17.0.0/16

--- a/litecoin/Dockerfile
+++ b/litecoin/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:14.04
 
-RUN apt-get update
+RUN apt-get update && apt-get install -qy git
 RUN apt-get install -qy build-essential
 RUN apt-get install -qy libboost-all-dev
-RUN apt-get install -qy git libssl-dev libdb++-dev libdb-dev libminiupnpc-dev
+RUN apt-get install -qy libssl-dev libdb++-dev libdb-dev libminiupnpc-dev
 RUN apt-get install -qy autoconf libtool pkg-config bsdmainutils libevent-dev
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
`docker build` attempts to install wrong version of `libcurl`. This is likely because the state of apt is changed when installing through `docker build` as opposed to installing inside the container. Fix is to install git in the same command as `apt-get update`.