### PR TITLE
Upgrade Go Deps + Readme in Ethereum Containers

### DIFF
--- a/ethereum-testnet/Dockerfile
+++ b/ethereum-testnet/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get install -qy build-essential
 RUN apt-get install -qy git libgmp3-dev wget
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN wget https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.4.2.linux-amd64.tar.gz
+RUN wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.8.linux-amd64.tar.gz
 
 RUN mkdir -p /root/go
 ENV PATH $PATH:/usr/local/go/bin

--- a/ethereum-testnet/README
+++ b/ethereum-testnet/README
@@ -1,10 +1,10 @@
 useful commands:
 ```
 docker build -t allofthecoins:ethereum-morden ./
-docker run --name ethereum -itd allofthecoins:ethereum-morden
+docker run --name ethereum-morden -itd allofthecoins:ethereum-morden
 docker exec -it ethereum-morden ./build/bin/geth --testnet --exec admin.peers attach ipc://root/.ethereum/testnet/geth.ipc
 docker exec -it ethereum-morden ./build/bin/geth --testnet --exec admin.nodeInfo attach ipc://root/.ethereum/testnet/geth.ipc
-docker exec -it tail -F /root/.ethereum/testnet/debug.log
+docker exec -it ethereum-morden tail -F /root/.ethereum/testnet/debug.log
 ```
 
 Runs the ethereum node (in the Morden testnet)

--- a/ethereum/Dockerfile
+++ b/ethereum/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get install -qy build-essential
 RUN apt-get install -qy git libgmp3-dev wget
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN wget https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.4.2.linux-amd64.tar.gz
+RUN wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.8.linux-amd64.tar.gz
 
 RUN mkdir -p /root/go
 ENV PATH $PATH:/usr/local/go/bin

--- a/ethereum/README
+++ b/ethereum/README
@@ -4,7 +4,7 @@ docker build -t allofthecoins:ethereum ./
 docker run --name ethereum -itd allofthecoins:ethereum
 docker exec -it ethereum ./build/bin/geth --exec admin.peers attach
 docker exec -it ethereum ./build/bin/geth --exec admin.nodeInfo attach
-docker exec -it tail -F /root/.ethereum/debug.log
+docker exec -it ethereum tail -F /root/.ethereum/debug.log
 ```
 
 Runs the ethereum node, listens of port 30303 on the host


### PR DESCRIPTION
Current Dockerfile errors out when building:
```
Sending build context to Docker daemon  2.56 kB
Step 1/16 : FROM ubuntu:14.04
 ---> 7c09e61e9035
Step 2/16 : RUN apt-get update
 ---> Using cache
 ---> f2697da1f82f
Step 3/16 : RUN apt-get install -qy build-essential
 ---> Using cache
 ---> 465ff8ee35ab
Step 4/16 : RUN apt-get install -qy git libgmp3-dev wget
 ---> Using cache
 ---> d38e0ed0bc2e
Step 5/16 : RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ---> Using cache
 ---> f227a8c5eeae
Step 6/16 : RUN wget https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz
 ---> Using cache
 ---> 3b5c3fa250ac
Step 7/16 : RUN tar -C /usr/local -xzf go1.4.2.linux-amd64.tar.gz
 ---> Using cache
 ---> b72339f20789
Step 8/16 : RUN mkdir -p /root/go
 ---> Using cache
 ---> 1155663a4404
Step 9/16 : ENV PATH $PATH:/usr/local/go/bin
 ---> Using cache
 ---> bf267781c4d8
Step 10/16 : ENV GOPATH /root/go
 ---> Using cache
 ---> d7ca06d7eed7
Step 11/16 : RUN git clone https://github.com/ethereum/go-ethereum
 ---> Using cache
 ---> 592a48e9ec55
Step 12/16 : WORKDIR go-ethereum
 ---> Using cache
 ---> 617292ddc76c
Step 13/16 : RUN make geth
 ---> Running in 6626cee22728
build/env.sh go run build/ci.go install ./cmd/geth
internal/build/azure.go:23:2: cannot find package "github.com/Azure/azure-sdk-for-go/storage" in any of:
	/usr/local/go/src/github.com/Azure/azure-sdk-for-go/storage (from $GOROOT)
	/go-ethereum/build/_workspace/src/github.com/Azure/azure-sdk-for-go/storage (from $GOPATH)
internal/build/pgp.go:27:2: cannot find package "golang.org/x/crypto/openpgp" in any of:
	/usr/local/go/src/golang.org/x/crypto/openpgp (from $GOROOT)
	/go-ethereum/build/_workspace/src/golang.org/x/crypto/openpgp (from $GOPATH)
make: *** [geth] Error 1
```