### PR TITLE
Update Readme for bitcoin-testnet

### DIFF
--- a/bitcoin-testnet/README.md
+++ b/bitcoin-testnet/README.md
@@ -10,5 +10,5 @@ docker exec -it tail -F /root/.bitcoin/debug.log
 Runs the bitcoin node, listens of port 18333 on the host, listens for local RPC connections on 18332
 
 ```shell
-docker run --name bitcoin -itd -p 18333:18333 -p 127.0.0.1:18332:18332 -v bitcoind-data:/root/.bitcoin allofthecoins:bitcoin
+docker run --name bitcoin -itd -p 18333:18333 -p 127.0.0.1:18332:18332 -v bitcoind-data:/root/.bitcoin allofthecoins:bitcoin-testnet
 ```


### PR DESCRIPTION
Typo in Readme. Looks like the ccommand was for bitcoin mainnet, the image name should be testnet